### PR TITLE
Fix edge function paths and sign-in redirect handling

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from "next/server"
 export async function GET(req: Request) {
   const url = new URL(req.url)
   const code = url.searchParams.get("code")
+  const redirect = url.searchParams.get("redirect") || "/dashboard"
 
   if (code) {
     const cookieStore = cookies()
@@ -18,5 +19,5 @@ export async function GET(req: Request) {
     }
   }
 
-  return NextResponse.redirect(new URL("/dashboard", url.origin))
+  return NextResponse.redirect(new URL(redirect, url.origin))
 }

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -5,10 +5,19 @@ import { ThemeSupa } from "@supabase/auth-ui-shared"
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
 import Link from "next/link"
 import { Gift } from "lucide-react"
+import { useSearchParams } from "next/navigation"
 
 const supabase = createClientComponentClient()
 
 export default function SignInPage() {
+  const searchParams = useSearchParams()
+  const redirectPath = searchParams.get("redirect") || "/dashboard"
+  const origin =
+    typeof window !== "undefined"
+      ? window.location.origin
+      : process.env.NEXT_PUBLIC_SITE_URL || ""
+  const redirectTo = `${origin}/auth/callback?redirect=${encodeURIComponent(redirectPath)}`
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-indigo-50 flex items-center justify-center p-4">
       <div className="w-full max-w-md">
@@ -66,7 +75,7 @@ export default function SignInPage() {
                 message: "text-sm text-red-600 mt-2",
               },
             }}
-            redirectTo={`${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`}
+            redirectTo={redirectTo}
             showLinks={false}
           />
 

--- a/components/admin/assistant-sync-panel.tsx
+++ b/components/admin/assistant-sync-panel.tsx
@@ -447,8 +447,7 @@ export function AssistantSyncPanel() {
                 <div className="space-y-2">
                   <label className="text-sm font-medium">Edge Function URL</label>
                   <div className="p-2 bg-gray-100 rounded text-sm font-mono">
-                    {process.env.NEXT_PUBLIC_SUPABASE_URL?.replace("https://", "").split(".")[0]}
-                    .functions.supabase.co/sync_assistants
+                    {process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/sync_assistants
                   </div>
                 </div>
 

--- a/lib/assistant-sync.ts
+++ b/lib/assistant-sync.ts
@@ -341,9 +341,8 @@ export const syncAssistantsToRegistry = async (assistants?: AssistantSyncData[])
       throw new Error("NEXT_PUBLIC_SUPABASE_URL is not configured")
     }
 
-    // Extract project ID from URL
-    const projectId = supabaseUrl.replace("https://", "").split(".")[0]
-    const edgeFunctionUrl = `https://${projectId}.functions.supabase.co/sync_assistants`
+    // Build Edge Function URL using Supabase project URL
+    const edgeFunctionUrl = `${supabaseUrl}/functions/v1/sync_assistants`
 
     console.log("[AGAI SYNC] Starting assistant registry sync...", {
       assistants_count: assistantsToSync.length,
@@ -396,8 +395,7 @@ export const fetchAssistantRegistry = async (): Promise<any> => {
       throw new Error("NEXT_PUBLIC_SUPABASE_URL is not configured")
     }
 
-    const projectId = supabaseUrl.replace("https://", "").split(".")[0]
-    const edgeFunctionUrl = `https://${projectId}.functions.supabase.co/sync_assistants`
+    const edgeFunctionUrl = `${supabaseUrl}/functions/v1/sync_assistants`
 
     const response = await fetch(edgeFunctionUrl, {
       method: "GET",


### PR DESCRIPTION
## Summary
- Build edge function URLs using the Supabase project URL (`/functions/v1/...`) to avoid 404 errors
- Show correct edge function URL in admin sync panel
- Respect `redirect` query params on sign-in and callback to prevent auth loops

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm type-check` *(fails: lib/future-integrations.ts parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_6897c5e56d8483328962411d38e5bce3