### PR TITLE
Refactor chart styles to remove dangerouslySetInnerHTML

### DIFF
--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -2,11 +2,12 @@
 
 import * as React from "react"
 import * as RechartsPrimitive from "recharts"
+import { useTheme } from "next-themes"
 
 import { cn } from "@/lib/utils"
 
-// Format: { THEME_NAME: CSS_SELECTOR }
-const THEMES = { light: "", dark: ".dark" } as const
+// Theme names used for dynamic chart colors
+const THEMES = { light: "light", dark: "dark" } as const
 
 export type ChartConfig = {
   [k in string]: {
@@ -45,6 +46,19 @@ const ChartContainer = React.forwardRef<
 >(({ id, className, children, config, ...props }, ref) => {
   const uniqueId = React.useId()
   const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+  const { resolvedTheme } = useTheme()
+
+  const style = React.useMemo<React.CSSProperties>(() => {
+    const vars: React.CSSProperties = {}
+    const theme = (resolvedTheme ?? "light") as keyof typeof THEMES
+    Object.entries(config).forEach(([key, item]) => {
+      const color = item.theme?.[theme] ?? item.color
+      if (color) {
+        ;(vars as any)[`--color-${key}`] = color
+      }
+    })
+    return vars
+  }, [config, resolvedTheme])
 
   return (
     <ChartContext.Provider value={{ config }}>
@@ -55,9 +69,9 @@ const ChartContainer = React.forwardRef<
           "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
           className
         )}
+        style={style}
         {...props}
       >
-        <ChartStyle id={chartId} config={config} />
         <RechartsPrimitive.ResponsiveContainer>
           {children}
         </RechartsPrimitive.ResponsiveContainer>
@@ -66,39 +80,6 @@ const ChartContainer = React.forwardRef<
   )
 })
 ChartContainer.displayName = "Chart"
-
-const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
-  const colorConfig = Object.entries(config).filter(
-    ([_, config]) => config.theme || config.color
-  )
-
-  if (!colorConfig.length) {
-    return null
-  }
-
-  return (
-    <style
-      dangerouslySetInnerHTML={{
-        __html: Object.entries(THEMES)
-          .map(
-            ([theme, prefix]) => `
-${prefix} [data-chart=${id}] {
-${colorConfig
-  .map(([key, itemConfig]) => {
-    const color =
-      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
-      itemConfig.color
-    return color ? `  --color-${key}: ${color};` : null
-  })
-  .join("\n")}
-}
-`
-          )
-          .join("\n"),
-      }}
-    />
-  )
-}
 
 const ChartTooltip = RechartsPrimitive.Tooltip
 
@@ -361,5 +342,4 @@ export {
   ChartTooltipContent,
   ChartLegend,
   ChartLegendContent,
-  ChartStyle,
 }


### PR DESCRIPTION
## Summary
- Generate chart color variables with React style objects instead of `<style>` tag
- Maintain light/dark theme support using `next-themes`

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm type-check` *(fails: lib/future-integrations.ts: error TS1005: '>' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_689f12f67a0c83328e45c8963098704d