### PR TITLE
Add runtime checks for Supabase env vars

### DIFF
--- a/lib/supabase/clients.ts
+++ b/lib/supabase/clients.ts
@@ -3,9 +3,18 @@
 
 import { cookies } from "next/headers";
 import { createBrowserClient, createServerClient } from "@supabase/ssr";
+import { env } from "@/lib/env";
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const url = env.NEXT_PUBLIC_SUPABASE_URL;
+const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!url) {
+  throw new Error("Environment variable NEXT_PUBLIC_SUPABASE_URL is not defined");
+}
+
+if (!anon) {
+  throw new Error("Environment variable NEXT_PUBLIC_SUPABASE_ANON_KEY is not defined");
+}
 
 export function getBrowserClient() {
   // use in "use client" components


### PR DESCRIPTION
## Summary
- add runtime checks for Supabase URL and anon key
- import typed env vars for Supabase clients

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint config)
- `npm run type-check` (fails: TypeScript errors in lib/future-integrations.ts)


------
https://chatgpt.com/codex/tasks/task_e_689f1485e1ec833295e7639b5828f02b