### PR TITLE
refactor: require supabase env vars for dynamic features

### DIFF
--- a/app/api/features/dynamic/route.ts
+++ b/app/api/features/dynamic/route.ts
@@ -1,12 +1,20 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@supabase/supabase-js"
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.SUPABASE_SERVICE_ROLE_KEY || "demo-key",
-)
-
 export async function GET() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error("Missing Supabase environment variables")
+    return NextResponse.json(
+      { error: "Server misconfiguration" },
+      { status: 500 },
+    )
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey)
+
   try {
     // Try to fetch from database, fallback to mock data if table doesn't exist or column missing
     const { data: features, error } = await supabase


### PR DESCRIPTION
## Summary
- require Supabase credentials in dynamic features endpoint
- return 500 error when env vars missing to avoid demo credentials

## Testing
- `pnpm lint` *(fails: prompts for configuration)*
- `pnpm type-check` *(fails: TS errors in lib/future-integrations.ts)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f14871d048332b0cff10d4ec68e28