### PR TITLE
Make fallback reason optional for granted access

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,8 +1,16 @@
 "use client"
 
 // Jest setup file for additional configuration
-import "@testing-library/jest-dom"
-import jest from "jest"
+require("@testing-library/jest-dom")
+
+jest.mock(
+  "@supabase/auth-helpers-nextjs",
+  () => ({
+    createClientComponentClient: jest.fn(),
+    createRouteHandlerClient: jest.fn(),
+  }),
+  { virtual: true }
+)
 
 // Mock Next.js router
 jest.mock("next/router", () => ({

--- a/lib/helpers/checkUserAccess.test.ts
+++ b/lib/helpers/checkUserAccess.test.ts
@@ -1,0 +1,27 @@
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
+import { checkUserAccess } from "./checkUserAccess"
+
+describe("checkUserAccess", () => {
+  it("omits fallbackReason when access is granted", async () => {
+    const mockSingle = jest.fn().mockResolvedValue({
+      data: { tier: "agent_00g", credits: 10, xp: 0, level: 0 },
+    })
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle })
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq })
+    const mockFrom = jest.fn().mockReturnValue({ select: mockSelect })
+    const mockSupabase = {
+      auth: {
+        getSession: jest
+          .fn()
+          .mockResolvedValue({ data: { session: { user: { id: "user1" } } } }),
+      },
+      from: mockFrom,
+    }
+    ;(createClientComponentClient as jest.Mock).mockReturnValue(mockSupabase)
+
+    const result = await checkUserAccess("gift-gut-check")
+
+    expect(result.accessGranted).toBe(true)
+    expect(result.fallbackReason).toBeUndefined()
+  })
+})

--- a/lib/helpers/checkUserAccess.ts
+++ b/lib/helpers/checkUserAccess.ts
@@ -7,7 +7,11 @@ import type { Database } from "@/types/supabase"
 
 export interface AccessCheckResult {
   accessGranted: boolean
-  fallbackReason: "no_auth" | "insufficient_tier" | "insufficient_credits" | "feature_disabled"
+  fallbackReason?:
+    | "no_auth"
+    | "insufficient_tier"
+    | "insufficient_credits"
+    | "feature_disabled"
   creditsLeft: number
   upgradeRequired: boolean
   requiredTier?: string
@@ -146,7 +150,6 @@ export async function checkUserAccess(featureName: string): Promise<AccessCheckR
     // Access granted
     return {
       accessGranted: true,
-      fallbackReason: "no_auth", // Won't be used
       creditsLeft: profile.credits || 0,
       upgradeRequired: false,
       currentTier: profile.tier,


### PR DESCRIPTION
## Summary
- make `fallbackReason` optional and omit it when access is granted
- add unit tests ensuring granted access returns no fallback reason
- mock Supabase helpers in Jest setup for stable tests

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_689f233f2eb483329fab4b47ef93e3de