### PR TITLE
chore: centralize Supabase client and enforce env validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,13 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## Environment Variables
+
+The application requires the following Supabase environment variables:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+These must be defined for both local development and production deployments.

--- a/app/admin/emotional-signature-engine/page.tsx
+++ b/app/admin/emotional-signature-engine/page.tsx
@@ -13,13 +13,11 @@ import { Separator } from "@/components/ui/separator"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, ResponsiveContainer, PieChart, Pie, Cell } from "recharts"
-import { createClient } from "@supabase/supabase-js"
+import { createClient } from "@/lib/supabase-client"
 import { Download, RefreshCw, Search, Send, X } from "lucide-react"
 
 // Initialize Supabase client
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ""
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ""
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+const supabase = createClient()
 
 // Emotion colors
 const EMOTION_COLORS = {

--- a/app/api/admin/economy-architect/functions/route.ts
+++ b/app/api/admin/economy-architect/functions/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/admin/economy-architect/voice/route.ts
+++ b/app/api/admin/economy-architect/voice/route.ts
@@ -1,8 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 import OpenAI from "openai"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 function getOpenAIClient() {
   return new OpenAI({

--- a/app/api/admin/feature-templates/route.ts
+++ b/app/api/admin/feature-templates/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.SUPABASE_SERVICE_ROLE_KEY || "demo-key",
-)
+const supabase = createAdminClient()
 
 export async function GET() {
   try {

--- a/app/api/admin/features/[id]/route.ts
+++ b/app/api/admin/features/[id]/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
   try {

--- a/app/api/admin/features/route.ts
+++ b/app/api/admin/features/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function GET() {
   try {

--- a/app/api/admin/giftverse-control/route.ts
+++ b/app/api/admin/giftverse-control/route.ts
@@ -1,8 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 import { withAuth } from "@/lib/middleware/withAuth"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export const POST = withAuth(async (request: NextRequest, context) => {
   try {

--- a/app/api/admin/giftverse-control/voice/route.ts
+++ b/app/api/admin/giftverse-control/voice/route.ts
@@ -1,8 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 import OpenAI from "openai"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 function getOpenAIClient() {
   return new OpenAI({

--- a/app/api/admin/giftverse-leader/intelligence/route.ts
+++ b/app/api/admin/giftverse-leader/intelligence/route.ts
@@ -1,8 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 import { withAuth } from "@/lib/middleware/withAuth"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export const POST = withAuth(async (request: NextRequest, context) => {
   try {

--- a/app/api/admin/giftverse-leader/settings/route.ts
+++ b/app/api/admin/giftverse-leader/settings/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/admin/giftverse-leader/voice/route.ts
+++ b/app/api/admin/giftverse-leader/voice/route.ts
@@ -1,8 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 import OpenAI from "openai"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 // Initialize OpenAI client only when needed
 function getOpenAIClient() {

--- a/app/api/admin/great-samaritan/participants/route.ts
+++ b/app/api/admin/great-samaritan/participants/route.ts
@@ -1,9 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
 export const dynamic = "force-dynamic"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/admin/reports/discord-webhook/route.ts
+++ b/app/api/admin/reports/discord-webhook/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/admin/reports/route.ts
+++ b/app/api/admin/reports/route.ts
@@ -1,9 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
 export const dynamic = "force-dynamic"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/admin/social-proofs/route.ts
+++ b/app/api/admin/social-proofs/route.ts
@@ -1,10 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.SUPABASE_SERVICE_ROLE_KEY || "demo-key",
-)
+const supabase = createAdminClient()
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/admin/sync-assistants/route.ts
+++ b/app/api/admin/sync-assistants/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 import { syncAssistantsToRegistry, AGENTGIFT_ASSISTANTS } from "@/lib/assistant-sync"
 
 // This API route provides server-side access to the sync function
@@ -7,7 +7,7 @@ import { syncAssistantsToRegistry, AGENTGIFT_ASSISTANTS } from "@/lib/assistant-
 export async function POST(request: NextRequest) {
   try {
     // Verify admin access
-    const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+    const supabase = createAdminClient()
 
     // Get the authorization header
     const authHeader = request.headers.get("authorization")
@@ -69,7 +69,7 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   try {
     // Verify admin access (same as POST)
-    const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+    const supabase = createAdminClient()
 
     const authHeader = request.headers.get("authorization")
     if (!authHeader) {

--- a/app/api/admin/visual-analytics/route.ts
+++ b/app/api/admin/visual-analytics/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/admin/voice-commands/route.ts
+++ b/app/api/admin/voice-commands/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/admin/voice-guardian/auth/route.ts
+++ b/app/api/admin/voice-guardian/auth/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/admin/voice-guardian/interact/route.ts
+++ b/app/api/admin/voice-guardian/interact/route.ts
@@ -1,8 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 import OpenAI from "openai"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 function getOpenAIClient() {
   return new OpenAI({

--- a/app/api/agentvault/bid/route.ts
+++ b/app/api/agentvault/bid/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/agentvault/coins/route.ts
+++ b/app/api/agentvault/coins/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/agentvault/items/route.ts
+++ b/app/api/agentvault/items/route.ts
@@ -1,9 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
 export const dynamic = "force-dynamic"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/agentvault/leaderboard/route.ts
+++ b/app/api/agentvault/leaderboard/route.ts
@@ -1,9 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
 export const dynamic = "force-dynamic"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/agentvault/rewards/route.ts
+++ b/app/api/agentvault/rewards/route.ts
@@ -1,9 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
 export const dynamic = "force-dynamic"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/agentvault/status/route.ts
+++ b/app/api/agentvault/status/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
 export const dynamic = "force-dynamic"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function GET() {
   try {

--- a/app/api/emotional-analytics/route.ts
+++ b/app/api/emotional-analytics/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function GET() {
   try {

--- a/app/api/emotional-signatures/route.ts
+++ b/app/api/emotional-signatures/route.ts
@@ -1,10 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
 // Initialize Supabase client
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ""
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || ""
-const supabase = createClient(supabaseUrl, supabaseServiceKey)
+const supabase = createAdminClient()
 
 // Webhook URL for Make.com integration
 const makeWebhookUrl = process.env.MAKE_WEBHOOK_URL || ""

--- a/app/api/features/dynamic/route.ts
+++ b/app/api/features/dynamic/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.SUPABASE_SERVICE_ROLE_KEY || "demo-key",
-)
+const supabase = createAdminClient()
 
 export async function GET() {
   try {

--- a/app/api/features/pride-alliance/route.ts
+++ b/app/api/features/pride-alliance/route.ts
@@ -1,10 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.SUPABASE_SERVICE_ROLE_KEY || "demo-key",
-)
+const supabase = createAdminClient()
 
 // Pride Alliance XP rewards
 const XP_REWARDS = {

--- a/app/api/functions/agentgift_features_query/route.ts
+++ b/app/api/functions/agentgift_features_query/route.ts
@@ -1,7 +1,7 @@
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 import { type NextRequest, NextResponse } from "next/server"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/orchestrator/finish-demo/route.ts
+++ b/app/api/orchestrator/finish-demo/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createServerClient } from "@/lib/supabase-client"
+import { createAdminClient } from "@/lib/supabase-client"
 import { sign } from "jsonwebtoken"
 import { z } from "zod"
 
@@ -28,7 +28,7 @@ export async function POST(request: NextRequest) {
     const validatedPayload = demoPayloadSchema.parse(body)
 
     // Create server client
-    const supabase = createServerClient()
+    const supabase = createAdminClient()
 
     // Insert demo session
     const { data: demoSession, error: demoError } = await supabase

--- a/app/api/social-campaigns/route.ts
+++ b/app/api/social-campaigns/route.ts
@@ -1,10 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.SUPABASE_SERVICE_ROLE_KEY || "demo-key",
-)
+const supabase = createAdminClient()
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/thought-heist/complete/route.ts
+++ b/app/api/thought-heist/complete/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/api/thought-heist/sessions/route.ts
+++ b/app/api/thought-heist/sessions/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+const supabase = createAdminClient()
 
 export async function POST(request: NextRequest) {
   try {

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,16 +1,12 @@
 // app/auth/callback/route.ts
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { createServerClient } from "@supabase/ssr";
+import { getServerClient } from "@/lib/supabase/clients";
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const next = url.searchParams.get("next") || "/dashboard";
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    { cookies }
-  );
+  const supabase = getServerClient();
   const code = url.searchParams.get("code");
   if (code) await supabase.auth.exchangeCodeForSession(code);
   return NextResponse.redirect(new URL(next, url.origin));

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { createBrowserClient } from "@supabase/ssr";
+import { getBrowserClient } from "@/lib/supabase/clients";
 import { Auth } from "@supabase/auth-ui-react";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -17,14 +17,7 @@ export default function AuthPage() {
   const searchParams = useSearchParams();
 
   // init browser client once
-  const supabase = useMemo(
-    () =>
-      createBrowserClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-      ),
-    []
-  );
+  const supabase = useMemo(() => getBrowserClient(), []);
 
   const [loading, setLoading] = useState(true);
   const [redirectTo, setRedirectTo] = useState("/dashboard");

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -5,17 +5,14 @@ import { ThemeSupa } from "@supabase/auth-ui-shared";
 // ⬇️ replace this:
 // import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 // ⬆️ with this:
-import { createBrowserClient } from "@supabase/ssr";
+import { getBrowserClient } from "@/lib/supabase/clients";
 
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Gift } from "lucide-react";
 
 // init browser client (works in client components)
-const supabase = createBrowserClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+const supabase = getBrowserClient();
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
 

--- a/components/persona/persona-context.tsx
+++ b/components/persona/persona-context.tsx
@@ -1,15 +1,12 @@
 "use client"
 
 import { createContext, useContext, useEffect, useState, type ReactNode } from "react"
-import { createClient } from "@supabase/supabase-js"
+import { createClient } from "@/lib/supabase-client"
 import { PersonaCulturalAdaptationService, type PersonaCulturalAdaptation } from "@/lib/persona-cultural-adaptation"
 import { useCulturalContext } from "@/components/cultural/cultural-context"
 
 // Initialize Supabase client
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "demo-key",
-)
+const supabase = createClient()
 
 export interface PersonaTheme {
   primary: string

--- a/components/vault/vault-gift-bid-panel.tsx
+++ b/components/vault/vault-gift-bid-panel.tsx
@@ -10,17 +10,14 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Textarea } from "@/components/ui/textarea"
 import { Coins, Zap, Crown, Gem, Star, Volume2, Trophy, Target, Flame, Loader2, Users, Timer } from "lucide-react"
 import { toast } from "sonner"
-import { createClient } from "@supabase/supabase-js"
+import { createClient } from "@/lib/supabase-client"
 
 // Lottie Player component
 import dynamic from "next/dynamic"
 const Lottie = dynamic(() => import("lottie-react"), { ssr: false })
 
 // Supabase client setup
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "demo-key",
-)
+const supabase = createClient()
 
 interface GiftItem {
   id: string

--- a/components/vault/vault-solo-panel.tsx
+++ b/components/vault/vault-solo-panel.tsx
@@ -20,13 +20,10 @@ import {
   Loader2,
 } from "lucide-react"
 import { toast } from "sonner"
-import { createClient } from "@supabase/supabase-js"
+import { createClient } from "@/lib/supabase-client"
 
 // Supabase client setup
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "demo-key",
-)
+const supabase = createClient()
 
 interface UserBalance {
   agt_tokens: number

--- a/features/ai-companion/route.ts
+++ b/features/ai-companion/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL || "", process.env.SUPABASE_SERVICE_ROLE_KEY || "")
+const supabase = createAdminClient()
 
 export async function POST(request: NextRequest) {
   try {

--- a/features/reminder-scheduler/route.ts
+++ b/features/reminder-scheduler/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL || "", process.env.SUPABASE_SERVICE_ROLE_KEY || "")
+const supabase = createAdminClient()
 
 export async function GET(request: NextRequest) {
   try {

--- a/features/social-proof-verifier/route.ts
+++ b/features/social-proof-verifier/route.ts
@@ -1,10 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { createClient } from "@supabase/supabase-js"
+import { createAdminClient } from "@/lib/supabase-client"
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.SUPABASE_SERVICE_ROLE_KEY || "demo-key",
-)
+const supabase = createAdminClient()
 
 // Helper function to extract hashtags from text
 function extractHashtags(text: string): string[] {

--- a/lib/external-services.ts
+++ b/lib/external-services.ts
@@ -1,12 +1,9 @@
 "use client"
 
-import { createClient } from "@supabase/supabase-js"
+import { createClient } from "@/lib/supabase-client"
 
 // Supabase client
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "demo-key",
-)
+const supabase = createClient()
 
 // Service definitions
 export const EXTERNAL_SERVICES = {

--- a/lib/feature-access.ts
+++ b/lib/feature-access.ts
@@ -1,12 +1,9 @@
 "use client"
 
-import { createClient } from "@supabase/supabase-js"
+import { createClient } from "@/lib/supabase-client"
 
 // Supabase client
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "demo-key",
-)
+const supabase = createClient()
 
 // Tier hierarchy and definitions
 export const TIERS = {

--- a/lib/fetchLocaleHolidayData.ts
+++ b/lib/fetchLocaleHolidayData.ts
@@ -1,8 +1,8 @@
 "use client"
 
-import { createClient } from "@supabase/supabase-js"
+import { createClient } from "@/lib/supabase-client"
 
-const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!)
+const supabase = createClient()
 
 export interface LocaleHoliday {
   id: string

--- a/lib/global-logic.ts
+++ b/lib/global-logic.ts
@@ -1,11 +1,8 @@
 "use client"
 
-import { createClient } from "@supabase/supabase-js"
+import { createClient } from "@/lib/supabase-client"
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "demo-key",
-)
+const supabase = createClient()
 
 // Global Constants
 export const XP_CONSTANTS = {

--- a/lib/persona-cultural-adaptation.ts
+++ b/lib/persona-cultural-adaptation.ts
@@ -1,9 +1,6 @@
-import { createClient } from "@supabase/supabase-js"
+import { createClient } from "@/lib/supabase-client"
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || "https://demo.supabase.co",
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "demo-key",
-)
+const supabase = createClient()
 
 export interface PersonaCulturalAdaptation {
   id: string

--- a/lib/supabase-client.ts
+++ b/lib/supabase-client.ts
@@ -1,0 +1,30 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js"
+import type { Database } from "@/types/supabase"
+
+export function createClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!url) {
+    throw new Error("Environment variable NEXT_PUBLIC_SUPABASE_URL is not defined")
+  }
+  if (!anonKey) {
+    throw new Error("Environment variable NEXT_PUBLIC_SUPABASE_ANON_KEY is not defined")
+  }
+
+  return createSupabaseClient<Database>(url, anonKey)
+}
+
+export function createAdminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url) {
+    throw new Error("Environment variable NEXT_PUBLIC_SUPABASE_URL is not defined")
+  }
+  if (!serviceRoleKey) {
+    throw new Error("Environment variable SUPABASE_SERVICE_ROLE_KEY is not defined")
+  }
+
+  return createSupabaseClient<Database>(url, serviceRoleKey)
+}


### PR DESCRIPTION
## Summary
- create shared Supabase client that validates required environment variables
- use shared client across API routes and components instead of inline fallbacks
- document required Supabase environment variables

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm type-check` *(fails: lib/future-integrations.ts syntax errors)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689f23407420833294ffad6ae71173b6