### PR TITLE
Handle Supabase session retrieval errors

### DIFF
--- a/app/api/emotitokens/send/route.ts
+++ b/app/api/emotitokens/send/route.ts
@@ -7,7 +7,13 @@ export async function POST(request: NextRequest) {
     const supabase = createRouteHandlerClient({ cookies })
     const {
       data: { session },
+      error,
     } = await supabase.auth.getSession()
+
+    if (error) {
+      console.error("Error retrieving session:", error)
+      throw error
+    }
 
     if (!session) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })

--- a/app/api/feature-access/route.ts
+++ b/app/api/feature-access/route.ts
@@ -8,7 +8,13 @@ export async function POST(request: NextRequest) {
     const supabase = createRouteHandlerClient({ cookies })
     const {
       data: { session },
+      error,
     } = await supabase.auth.getSession()
+
+    if (error) {
+      console.error("Error retrieving session:", error)
+      throw error
+    }
 
     if (!session) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
@@ -88,7 +94,13 @@ export async function GET(request: NextRequest) {
     const supabase = createRouteHandlerClient({ cookies })
     const {
       data: { session },
+      error,
     } = await supabase.auth.getSession()
+
+    if (error) {
+      console.error("Error retrieving session:", error)
+      throw error
+    }
 
     if (!session) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })

--- a/app/api/serendipity/echo/route.ts
+++ b/app/api/serendipity/echo/route.ts
@@ -9,7 +9,13 @@ export async function POST(request: NextRequest) {
     const supabase = createRouteHandlerClient({ cookies })
     const {
       data: { session },
+      error,
     } = await supabase.auth.getSession()
+
+    if (error) {
+      console.error("Error retrieving session:", error)
+      throw error
+    }
 
     if (!session) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })

--- a/app/api/serendipity/reveal/route.ts
+++ b/app/api/serendipity/reveal/route.ts
@@ -9,7 +9,13 @@ export async function POST(request: NextRequest) {
     const supabase = createRouteHandlerClient({ cookies })
     const {
       data: { session },
+      error,
     } = await supabase.auth.getSession()
+
+    if (error) {
+      console.error("Error retrieving session:", error)
+      throw error
+    }
 
     if (!session) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })

--- a/app/api/serendipity/save/route.ts
+++ b/app/api/serendipity/save/route.ts
@@ -7,7 +7,13 @@ export async function POST(request: NextRequest) {
     const supabase = createRouteHandlerClient({ cookies })
     const {
       data: { session },
+      error,
     } = await supabase.auth.getSession()
+
+    if (error) {
+      console.error("Error retrieving session:", error)
+      throw error
+    }
 
     if (!session) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })

--- a/app/api/services/route.ts
+++ b/app/api/services/route.ts
@@ -8,7 +8,13 @@ export async function POST(request: NextRequest) {
     const supabase = createRouteHandlerClient({ cookies })
     const {
       data: { session },
+      error,
     } = await supabase.auth.getSession()
+
+    if (error) {
+      console.error("Error retrieving session:", error)
+      throw error
+    }
 
     if (!session) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
@@ -40,7 +46,13 @@ export async function GET(request: NextRequest) {
     const supabase = createRouteHandlerClient({ cookies })
     const {
       data: { session },
+      error,
     } = await supabase.auth.getSession()
+
+    if (error) {
+      console.error("Error retrieving session:", error)
+      throw error
+    }
 
     if (!session) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -38,16 +38,28 @@ export default function AuthPage() {
     }
 
     const checkAuth = async () => {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
+      try {
+        const {
+          data: { session },
+          error,
+        } = await supabase.auth.getSession();
 
-      if (session) {
-        await triggerOnboarding();
-        router.push(redirect ?? "/dashboard");
-        return;
+        if (error) {
+          console.error("Error retrieving session:", error);
+          setLoading(false);
+          return;
+        }
+
+        if (session) {
+          await triggerOnboarding();
+          router.push(redirect ?? "/dashboard");
+          return;
+        }
+        setLoading(false);
+      } catch (error) {
+        console.error("checkAuth error:", error);
+        setLoading(false);
       }
-      setLoading(false);
     };
 
     checkAuth();

--- a/components/admin/assistant-sync-panel.tsx
+++ b/components/admin/assistant-sync-panel.tsx
@@ -54,7 +54,12 @@ export function AssistantSyncPanel() {
       // Get current user token
       const {
         data: { session },
+        error,
       } = await supabase.auth.getSession()
+      if (error) {
+        console.error("Error retrieving session:", error)
+        throw error
+      }
       if (!session) {
         throw new Error("Authentication required")
       }
@@ -100,7 +105,12 @@ export function AssistantSyncPanel() {
 
       const {
         data: { session },
+        error,
       } = await supabase.auth.getSession()
+      if (error) {
+        console.error("Error retrieving session:", error)
+        throw error
+      }
       if (!session) return
 
       const response = await fetch("/api/admin/sync-assistants", {

--- a/components/registry/agent-gift-master-registry.tsx
+++ b/components/registry/agent-gift-master-registry.tsx
@@ -178,7 +178,13 @@ export function AgentGiftMasterRegistry({ className = "", showAdminControls = fa
     try {
       const {
         data: { session },
+        error,
       } = await supabase.auth.getSession()
+
+      if (error) {
+        console.error("Error retrieving session:", error)
+        throw error
+      }
 
       if (session?.user) {
         const { data: profile } = await supabase.from("user_profiles").select("*").eq("id", session.user.id).single()
@@ -206,7 +212,13 @@ export function AgentGiftMasterRegistry({ className = "", showAdminControls = fa
 
       const {
         data: { session },
+        error: sessionError,
       } = await supabase.auth.getSession()
+
+      if (sessionError) {
+        console.error("Error retrieving session:", sessionError)
+        throw sessionError
+      }
 
       // Call Edge Function with filters
       const { data, error } = await supabase.functions.invoke("agentgift_features_query", {

--- a/lib/helpers/checkUserAccess.ts
+++ b/lib/helpers/checkUserAccess.ts
@@ -69,7 +69,13 @@ export async function checkUserAccess(featureName: string): Promise<AccessCheckR
     // Check authentication
     const {
       data: { session },
+      error,
     } = await supabase.auth.getSession()
+
+    if (error) {
+      console.error("Error retrieving session:", error)
+      throw error
+    }
 
     if (!session) {
       return {

--- a/lib/middleware/withAuth.ts
+++ b/lib/middleware/withAuth.ts
@@ -44,6 +44,10 @@ export function withAuth<T extends any[]>(
         error: sessionError,
       } = await supabase.auth.getSession()
 
+      if (sessionError) {
+        console.error("Error retrieving session:", sessionError)
+      }
+
       if (sessionError || !session) {
         return NextResponse.json({ error: "Authentication required", redirect: "/login" }, { status: 401 })
       }
@@ -174,7 +178,13 @@ export async function requireAuth(): Promise<AuthenticatedUser | null> {
 
     const {
       data: { session },
+      error,
     } = await supabase.auth.getSession()
+
+    if (error) {
+      console.error("Error retrieving session:", error)
+      return null
+    }
     if (!session) return null
 
     const { data: profile } = await supabase.from("user_profiles").select("*").eq("id", session.user.id).single()

--- a/lib/trpc/server.ts
+++ b/lib/trpc/server.ts
@@ -14,6 +14,10 @@ export const createTRPCContext = async (opts: { req?: Request }) => {
     error,
   } = await supabase.auth.getSession()
 
+  if (error) {
+    console.error("Error retrieving session:", error)
+  }
+
   return {
     supabase,
     adminSupabase,

--- a/middleware.ts
+++ b/middleware.ts
@@ -21,7 +21,13 @@ export async function middleware(req: NextRequest) {
     // Refresh session if expired - required for Server Components
     const {
       data: { session },
+      error,
     } = await supabase.auth.getSession()
+
+    if (error) {
+      console.error("Error retrieving session:", error)
+      throw error
+    }
 
     // Protected routes that require authentication
     const protectedRoutes = [


### PR DESCRIPTION
## Summary
- check `error` returned by `supabase.auth.getSession`
- log and rethrow session retrieval failures across middleware, API routes, and components
- update auth flow to handle session errors gracefully

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm type-check` *(fails: lib/future-integrations.ts syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f233ffc708332b9380d626474a577