### PR TITLE
fix: ensure auth pages redirect without NEXT_PUBLIC_SITE_URL

### DIFF
--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -14,6 +14,12 @@ export default function SignInPage() {
   const searchParams = useSearchParams()
   const redirectTo = searchParams.get("redirect_to") || "/dashboard"
 
+  // Determine site URL for Supabase redirect. Falls back to window origin if
+  // NEXT_PUBLIC_SITE_URL isn't specified to prevent undefined callbacks.
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    (typeof window !== "undefined" ? window.location.origin : "")
+
   useEffect(() => {
     // Set redirect cookie for auth callback
     if (redirectTo) {
@@ -70,15 +76,15 @@ export default function SignInPage() {
                   },
                 },
               },
-              className: {
-                container: "space-y-4",
-                button: "w-full px-4 py-3 font-medium transition-all duration-200",
-                input: "w-full px-4 py-3 transition-all duration-200",
-                label: "text-sm font-medium text-gray-700 mb-2",
-                message: "text-sm text-red-600 mt-2",
-              },
-            }}
-            redirectTo={`${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`}
+            className: {
+              container: "space-y-4",
+              button: "w-full px-4 py-3 font-medium transition-all duration-200",
+              input: "w-full px-4 py-3 transition-all duration-200",
+              label: "text-sm font-medium text-gray-700 mb-2",
+              message: "text-sm text-red-600 mt-2",
+            },
+          }}
+            redirectTo={`${siteUrl}/auth/callback`}
             showLinks={false}
           />
 

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -14,6 +14,13 @@ export default function SignUpPage() {
   const searchParams = useSearchParams()
   const redirectTo = searchParams.get("redirect_to") || "/dashboard"
 
+  // Determine site URL for Supabase redirect. Falls back to the current
+  // browser origin if NEXT_PUBLIC_SITE_URL isn't configured which avoids
+  // generating `undefined/auth/callback` during deployment.
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    (typeof window !== "undefined" ? window.location.origin : "")
+
   useEffect(() => {
     // Set redirect cookie for auth callback
     if (redirectTo) {
@@ -70,15 +77,15 @@ export default function SignUpPage() {
                   },
                 },
               },
-              className: {
-                container: "space-y-4",
-                button: "w-full px-4 py-3 font-medium transition-all duration-200",
-                input: "w-full px-4 py-3 transition-all duration-200",
-                label: "text-sm font-medium text-gray-700 mb-2",
-                message: "text-sm text-red-600 mt-2",
-              },
-            }}
-            redirectTo={`${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`}
+          className: {
+            container: "space-y-4",
+            button: "w-full px-4 py-3 font-medium transition-all duration-200",
+            input: "w-full px-4 py-3 transition-all duration-200",
+            label: "text-sm font-medium text-gray-700 mb-2",
+            message: "text-sm text-red-600 mt-2",
+          },
+        }}
+            redirectTo={`${siteUrl}/auth/callback`}
             showLinks={false}
           />
 


### PR DESCRIPTION
## Summary
- guard against undefined `NEXT_PUBLIC_SITE_URL` on auth pages by using browser origin

## Testing
- `pnpm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a975c88eb8833287e58cfdb20d93e9